### PR TITLE
Disable automatic locale detection to default to English

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -2,6 +2,5 @@ module.exports = {
   i18n: {
     locales: ["en", "pt"],
     defaultLocale: "en",
-    localeDetection: false,
   },
 };

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -2,5 +2,6 @@ module.exports = {
   i18n: {
     locales: ["en", "pt"],
     defaultLocale: "en",
+    localeDetection: false,
   },
 };

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,6 +1,6 @@
 {
   "fullstack-developer.label": "Fullstack Developer",
-  "description": "Software engineer from Curitiba, Brazil — with experience across Brazilian startups and international companies. Full-stack by trade, backend by nature. From insurtech and virtual offices to fintech, I build systems that scale.",
+  "description": "Software engineer from Curitiba, Brazil — with experience across Brazilian startups and international companies. Genuinely full-stack, with a lean toward backend. From insurtech and virtual offices to fintech, I build systems that scale.",
   "talk-to-me.label": "Talk to me!",
   "try-my-email": "You can try contacting me by my email",
   "other-social-media": "Or by any other social media down below!",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,6 +1,6 @@
 {
   "fullstack-developer.label": "Fullstack Developer",
-  "description": "Software engineer from Curitiba, Brazil — with experience across Brazilian startups and international companies. Full-stack, with a lean toward backend. From insurtech and virtual offices to fintech, I build systems that scale.",
+  "description": "Software engineer from Curitiba, Brazil — with experience across Brazilian startups and international companies. Full-stack, with a lean toward backend. From insurtech and virtual offices to fintech, I build systems that scale. Let's work together.",
   "talk-to-me.label": "Talk to me!",
   "try-my-email": "You can try contacting me by my email",
   "other-social-media": "Or by any other social media down below!",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,6 +1,6 @@
 {
   "fullstack-developer.label": "Fullstack Developer",
-  "description": "Welcome to my portfolio! I'm a software engineer, born in Curitiba (Brazil), passionate about technology and the power it has to impact real people. I have full-stack experience — working with frontend, mobile, but mostly backend. Let's connect and build something amazing together?",
+  "description": "Software engineer from Curitiba, Brazil — with experience across Brazilian startups and international companies. Full-stack by trade, backend by nature. From insurtech and virtual offices to fintech, I build systems that scale.",
   "talk-to-me.label": "Talk to me!",
   "try-my-email": "You can try contacting me by my email",
   "other-social-media": "Or by any other social media down below!",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,6 +1,6 @@
 {
   "fullstack-developer.label": "Fullstack Developer",
-  "description": "Software engineer from Curitiba, Brazil — with experience across Brazilian startups and international companies. Genuinely full-stack, with a lean toward backend. From insurtech and virtual offices to fintech, I build systems that scale.",
+  "description": "Software engineer from Curitiba, Brazil — with experience across Brazilian startups and international companies. Full-stack, with a lean toward backend. From insurtech and virtual offices to fintech, I build systems that scale.",
   "talk-to-me.label": "Talk to me!",
   "try-my-email": "You can try contacting me by my email",
   "other-social-media": "Or by any other social media down below!",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -1,6 +1,6 @@
 {
   "fullstack-developer.label": "Desenvolvedor Fullstack",
-  "description": "Engenheiro de software curitibano com passagem por startups brasileiras e empresas internacionais. Fullstack, com uma queda pelo backend. De insurtechs a fintechs, construo sistemas que escalam.",
+  "description": "Engenheiro de software curitibano com passagem por startups brasileiras e empresas internacionais. Fullstack, com uma queda pelo backend. De insurtechs a fintechs, construo sistemas que escalam. Vamos trabalhar juntos.",
   "talk-to-me": {
     "label": "Fale comigo!"
   },

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -1,6 +1,6 @@
 {
   "fullstack-developer.label": "Desenvolvedor Fullstack",
-  "description": "Engenheiro de software curitibano com passagem por startups brasileiras e empresas internacionais. Fullstack por formação, backend por vocação. De insurtechs a fintechs, construo sistemas que escalam.",
+  "description": "Engenheiro de software curitibano com passagem por startups brasileiras e empresas internacionais. Genuinamente fullstack, com uma queda pelo backend. De insurtechs a fintechs, construo sistemas que escalam.",
   "talk-to-me": {
     "label": "Fale comigo!"
   },

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -1,6 +1,6 @@
 {
   "fullstack-developer.label": "Desenvolvedor Fullstack",
-  "description": "Bem-vindo ao meu portfólio! Sou um engenheiro de software, nascido em Curitiba, apaixonado pela tecnologia e o poder que ela tem de impactar a vida de pessoas reais. Tenho experiência fullstack, tanto com frontend, mobile, mas principalmente backend. Vamos nos conectar e contruir algo incível juntos?",
+  "description": "Engenheiro de software curitibano com passagem por startups brasileiras e empresas internacionais. Fullstack por formação, backend por vocação. De insurtechs a fintechs, construo sistemas que escalam.",
   "talk-to-me": {
     "label": "Fale comigo!"
   },

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -1,6 +1,6 @@
 {
   "fullstack-developer.label": "Desenvolvedor Fullstack",
-  "description": "Engenheiro de software curitibano com passagem por startups brasileiras e empresas internacionais. Fullstack, com uma queda pelo backend. De insurtechs a fintechs, construo sistemas que escalam. Vamos trabalhar juntos.",
+  "description": "Engenheiro de software curitibano com passagem por startups brasileiras e empresas internacionais. Fullstack, com uma quedinha pelo backend. De insurtechs a fintechs, construo sistemas que escalam. Vamos trabalhar juntos?",
   "talk-to-me": {
     "label": "Fale comigo!"
   },

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -1,6 +1,6 @@
 {
   "fullstack-developer.label": "Desenvolvedor Fullstack",
-  "description": "Engenheiro de software curitibano com passagem por startups brasileiras e empresas internacionais. Genuinamente fullstack, com uma queda pelo backend. De insurtechs a fintechs, construo sistemas que escalam.",
+  "description": "Engenheiro de software curitibano com passagem por startups brasileiras e empresas internacionais. Fullstack, com uma queda pelo backend. De insurtechs a fintechs, construo sistemas que escalam.",
   "talk-to-me": {
     "label": "Fale comigo!"
   },


### PR DESCRIPTION
Next.js was auto-detecting the browser's Accept-Language header and
redirecting Portuguese-language browsers to /pt on initial load.
Setting localeDetection: false ensures the site always loads in English
by default, with language switching left to the user.

https://claude.ai/code/session_01CfbtTt2Jy5ssiPAoP1mnc7